### PR TITLE
Make SARS-CoV-2 gene map compatible with GFF3 spec

### DIFF
--- a/sars-cov-2/references/MN908947/genemap.gff
+++ b/sars-cov-2/references/MN908947/genemap.gff
@@ -1,16 +1,18 @@
+##gff-version 3
+##sequence-region MN908947 1 29903
 # Gene map (genome annotation) of SARS-CoV-2 in GFF format.
 # For gene map purpses we only need some of the columns. We substitute unused values with "." as per GFF spec.
 # See GFF format reference at https://www.ensembl.org/info/website/upload/gff.html
 # seqname	source	feature	start	end	score	strand	frame	attribute
-.	.	gene	26245	26472	.	+	.	gene_name=E
-.	.	gene	26523	27191	.	+	.	gene_name=M
-.	.	gene	28274	29533	.	+	.	gene_name=N
-.	.	gene	266	13468	.	+	.	gene_name=ORF1a
-.	.	gene	13468	21555	.	+	.	gene_name=ORF1b
-.	.	gene	25393	26220	.	+	.	gene_name=ORF3a
-.	.	gene	27202	27387	.	+	.	gene_name=ORF6
-.	.	gene	27394	27759	.	+	.	gene_name=ORF7a
-.	.	gene	27756	27887	.	+	.	gene_name=ORF7b
-.	.	gene	27894	28259	.	+	.	gene_name=ORF8
-.	.	gene	28284	28577	.	+	.	gene_name=ORF9b
-.	.	gene	21563	25384	.	+	.	gene_name=S
+MN908947	GenBank	gene	26245	26472	.	+	.	gene_name=E
+MN908947	GenBank	gene	26523	27191	.	+	.	gene_name=M
+MN908947	GenBank	gene	28274	29533	.	+	.	gene_name=N
+MN908947	GenBank	gene	266	13468	.	+	.	gene_name=ORF1a
+MN908947	GenBank	gene	13468	21555	.	+	.	gene_name=ORF1b
+MN908947	GenBank	gene	25393	26220	.	+	.	gene_name=ORF3a
+MN908947	GenBank	gene	27202	27387	.	+	.	gene_name=ORF6
+MN908947	GenBank	gene	27394	27759	.	+	.	gene_name=ORF7a
+MN908947	GenBank	gene	27756	27887	.	+	.	gene_name=ORF7b
+MN908947	GenBank	gene	27894	28259	.	+	.	gene_name=ORF8
+MN908947	GenBank	gene	28284	28577	.	+	.	gene_name=ORF9b
+MN908947	GenBank	gene	21563	25384	.	+	.	gene_name=S


### PR DESCRIPTION
Updates the SARS-CoV-2 GFF for the gene map to make it more compatible with GFF3 specification [1] including addition of a GFF version in the first line, sequence-region pragma specifying the full length of the reference sequence, sequence id values in the sequence id column, and "GenBank" in the source column.

[1] https://github.com/The-Sequence-Ontology/Specifications/blob/master/gff3.md