### PR TITLE
Align SC2 with new clades tsvs in ncov

### DIFF
--- a/sars-cov-2/profiles/clades/21L/auspice_config.json
+++ b/sars-cov-2/profiles/clades/21L/auspice_config.json
@@ -19,6 +19,24 @@
           "displayName": "Unaliased",
           "description": "Partially aliased reconstructed Pango lineage",
           "hideInWeb": false
+        },
+        {
+          "name": "clade_nextstrain",
+          "displayName": "Nextstrain Clade",
+          "description": "Nextstrain Clade",
+          "hideInWeb": true
+        },
+        {
+          "name": "clade_who",
+          "displayName": "WHO name",
+          "description": "Greek letter WHO name",
+          "hideInWeb": true
+        },
+        {
+          "name": "clade_display",
+          "displayName": "Clade display name",
+          "description": "Combination of Nextstrain clade and Pango lineage",
+          "hideInWeb": true
         }
       ]
     }
@@ -83,6 +101,21 @@
       "key": "totalAminoacidDeletions",
       "title": "Total amino acid deletions",
       "type": "continuous"
+    },
+    {
+      "key": "clade_who",
+      "title": "WHO name",
+      "type": "categorical"
+    },
+    {
+      "key": "clade_nextstrain",
+      "title": "Nextstrain clade name",
+      "type": "categorical"
+    },
+    {
+      "key": "clade_display",
+      "title": "Display clade name",
+      "type": "categorical"
     }
   ],
   "display_defaults": {
@@ -98,6 +131,8 @@
     "Nextclade_pango",
     "partiallyAliased",
     "designation_recency",
+    "clade_who",
+    "clade_display",
     "designation_date"
   ],
   "panels": ["tree", "entropy"]

--- a/sars-cov-2/profiles/clades/wuhan/auspice_config.json
+++ b/sars-cov-2/profiles/clades/wuhan/auspice_config.json
@@ -33,9 +33,9 @@
           "hideInWeb": false
         },
         {
-          "name": "clade_legacy",
-          "displayName": "Backwards compatible Nextstrain name",
-          "description": "Combination of Nextstrain clade, WHO name and other names like EU1 for backwards compatibility",
+          "name": "clade_display",
+          "displayName": "Clade display name",
+          "description": "Combination of Nextstrain clade and Pango lineage",
           "hideInWeb": true
         }
       ]
@@ -73,8 +73,8 @@
       "type": "categorical"
     },
     {
-      "key": "clade_legacy",
-      "title": "Legacy clade name",
+      "key": "clade_display",
+      "title": "Display clade name",
       "type": "categorical"
     },
     {
@@ -131,7 +131,7 @@
     "Nextclade_pango",
     "partiallyAliased",
     "clade_who",
-    "clade_legacy",
+    "clade_display",
     "designation_date",
     "designation_recency"
   ],

--- a/sars-cov-2/scripts/rename_clades.py
+++ b/sars-cov-2/scripts/rename_clades.py
@@ -1,0 +1,50 @@
+import argparse
+import yaml
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Rename clades in clades.tsv",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--input-clade-files",
+        type=str,
+        nargs="+",
+        required=True,
+        help="input clade files",
+    )
+    parser.add_argument(
+        "--name-mapping",
+        type=str,
+        required=False,
+        help="YAML mapping between Nextstrain clades and display names",
+    )
+    parser.add_argument(
+        "--output-clades", type=str, required=True, help="renamed clade file"
+    )
+    args = parser.parse_args()
+
+    # read name mapping from input yaml file
+    if args.name_mapping:
+        with open(args.name_mapping) as fh:
+            name_mapping = yaml.load(fh, Loader=yaml.FullLoader)
+    else:
+        name_mapping = {}
+
+    # write output into one consolidated file
+    out_clades = open(args.output_clades, "w")
+
+    # loop over input file and replace clade names were appropriate line by line
+    for fname in args.input_clade_files:
+        with open(fname) as fh:
+            for line in fh:
+                fields = line.strip("\n").split("\t")
+                if len(fields) < 3:
+                    continue
+                fields[0] = name_mapping.get(fields[0], fields[0])
+                # if clade definition is based on other clade, replace name
+                if fields[1] == "clade":
+                    fields[2] = name_mapping.get(fields[2], fields[2])
+                out_clades.write("\t".join(fields) + "\n")
+
+    out_clades.close()

--- a/sars-cov-2/workflow/snakemake_rules/core.smk
+++ b/sars-cov-2/workflow/snakemake_rules/core.smk
@@ -359,18 +359,18 @@ rule preprocess_clades:
         """
 
 
-rule clades_legacy:
+rule clades_display:
     input:
         tree=rules.refine.output.tree,
         aa_muts=rules.translate.output.node_data,
         nuc_muts=rules.ancestral.output.node_data,
-        clades="builds/{build_name}/clades.tsv",
+        clades="builds/{build_name}/clades_display.tsv",
         internal_pango=rules.internal_pango.output.node_data,
         alias=rules.download_pango_alias.output,
     output:
-        node_data="builds/{build_name}/clades_legacy.json",
+        node_data="builds/{build_name}/clades_display.json",
     params:
-        tmp="builds/{build_name}/clades_legacy.tmp",
+        tmp="builds/{build_name}/clades_display.tmp",
     shell:
         """
         augur clades --tree {input.tree} \
@@ -381,10 +381,10 @@ rule clades_legacy:
             --clades {params.tmp} \
             --internal-pango {input.internal_pango} \
             --alias {input.alias} \
-            --clade-type clade_legacy \
+            --clade-type clade_display \
             --output {output.node_data}
         rm {params.tmp}
-        sed -i'' 's/clade_membership/clade_legacy/gi' {output.node_data}
+        sed -i'' 's/clade_membership/clade_display/gi' {output.node_data}
         """
 
 
@@ -474,7 +474,7 @@ def _get_node_data_by_wildcards(wildcards):
         rules.refine.output.node_data,
         rules.ancestral.output.node_data,
         rules.translate.output.node_data,
-        rules.clades_legacy.output.node_data,
+        rules.clades_display.output.node_data,
         rules.clades.output.node_data,
         rules.clades.output.node_data_nextstrain,
         rules.clades_who.output.node_data,

--- a/sars-cov-2/workflow/snakemake_rules/preprocess.smk
+++ b/sars-cov-2/workflow/snakemake_rules/preprocess.smk
@@ -67,13 +67,11 @@ rule download_metadata:
         "aws s3 cp {params.address} {output:q}"
 
 
-rule download_clades:
-    message:
-        "Downloading clade definitions from {params.source} -> {output}"
+rule download_clade_display_names:
     output:
-        "builds/clades.tsv",
+        "builds/clade_display_names.yml",
     params:
-        source="https://raw.githubusercontent.com/nextstrain/ncov/master/defaults/clades.tsv",
+        source="https://raw.githubusercontent.com/nextstrain/ncov/master/defaults/clade_display_names.yml",
     shell:
         "curl {params.source} -o {output}"
 
@@ -84,9 +82,24 @@ rule download_clades_nextstrain:
     output:
         "builds/clades_nextstrain.tsv",
     params:
-        source="https://raw.githubusercontent.com/nextstrain/ncov/master/defaults/clades_nextstrain.tsv",
+        source="https://raw.githubusercontent.com/nextstrain/ncov/master/defaults/clades.tsv",
     shell:
         "curl {params.source} -o {output}"
+
+
+rule nextstrain_clades_to_legacy:
+    input:
+        clade_file="builds/clades_nextstrain.tsv",
+        display_names="builds/clade_display_names.yml",
+    output:
+        "builds/clades_display.tsv",
+    shell:
+        """
+        python3 scripts/rename_clades.py \
+            --input-clade-files {input.clade_file} \
+            --name-mapping {input.display_names} \
+            --output-clades {output}
+        """
 
 
 rule download_clades_who:


### PR DESCRIPTION
See https://github.com/nextstrain/ncov/pull/1065
Clade legacy is hence deprecated
We now have a new column "display clade name" which is a combination
of Nextstrain clade and Pango lineage, e.g. "23B (XBB.1.16)"
